### PR TITLE
(int) player.x => player.getFloorX()

### DIFF
--- a/src/main/java/warp/Warp.java
+++ b/src/main/java/warp/Warp.java
@@ -64,9 +64,9 @@ public class Warp extends PluginBase implements Listener {
         @EventHandler
 	public void MovingCheck(PlayerMoveEvent event){
 		Player player = event.getPlayer();
-		int x = (int) player.x;
-		int y = (int) player.y;
-		int z = (int) player.z;
+		int x = player.getFloorX();
+		int y = player.getFloorY();
+		int z = player.getFloorZ();
 		
 		if(player.level.getBlockIdAt(x, y, z) == Item.SIGN_POST || player.level.getBlockIdAt(x, y, z) == Item.WALL_SIGN){
 			BlockEntitySign t = (BlockEntitySign) player.level.getBlockEntity(new Vector3(x, y, z));


### PR DESCRIPTION
플레이어 좌표가 마이너스일 때 1칸 오차나는 오류 수정

예시) X좌표가 -3.3일 경우

(int) player.x  >  -3
player.getFloorX()  >  -4
